### PR TITLE
Mobile nav menu aanpassingen

### DIFF
--- a/src/layouts/NavMobile.vue
+++ b/src/layouts/NavMobile.vue
@@ -84,7 +84,7 @@ router.afterEach(() => {
                 title="Goto submenu"
                 class="sub-menu-toggle"
                 @click="setCurrentLevel(2, item.title)"
-                >‌‌ ‌‌ ‌‌▸‌‌ ‌‌ ‌‌‌‌ ‌‌‌
+              >‌‌ ‌‌ ‌‌▸‌‌ ‌‌ ‌‌‌‌ ‌‌‌
               </a>
 
               <div
@@ -120,7 +120,7 @@ router.afterEach(() => {
                         title="Goto sub-submenu"
                         class="sub-menu-toggle"
                         @click="setCurrentLevel(3, child.title)"
-                        >‌‌ ‌‌ ‌‌▸‌‌ ‌‌ ‌‌‌‌ ‌‌‌
+                      >‌‌ ‌‌ ‌‌▸‌‌ ‌‌ ‌‌‌‌ ‌‌‌
                       </a>
 
                       <div
@@ -182,8 +182,9 @@ router.afterEach(() => {
   --navbar-height: 16vw;
   --navbar-max-height: 68px;
   --transition-time: 0.2s;
-  --linespace: 5vw;
-  --shadowspace: 10vw;
+  --linespace: 3vw;
+  --shadowspace: 6vw;
+  --linespace-transition-delay: calc(var(--transition-time) * 0.5);
 
   a {
     cursor: pointer;
@@ -225,7 +226,7 @@ router.afterEach(() => {
       display: flex;
       cursor: pointer;
       stroke: var(--text-color);
-      padding-bottom: 0px;
+      padding-bottom: 0;
       position: relative;
       padding-left: 10px;
       padding-right: 10px;
@@ -303,14 +304,14 @@ router.afterEach(() => {
       height: 100%;
       width: 100vw - var(--shadowspace); // 100%
       transition: var(--transition-time) ease-in-out;
-      transition-delay: var(--transition-time);
+      transition-delay: var(--linespace-transition-delay);
 
       &.blue {
         background-color: var(--indi-blue-1);
 
         &.visible {
           left: (var(--shadowspace));
-          transition-delay: 0s;
+          transition-delay: var(--linespace-transition-delay);
         }
       }
 
@@ -322,7 +323,7 @@ router.afterEach(() => {
 
         &.visible {
           left: 0;
-          transition-delay: 0s;
+          transition-delay: var(--linespace-transition-delay);
         }
       }
 
@@ -334,12 +335,11 @@ router.afterEach(() => {
 
         &.visible {
           left: 0;
-          transition-delay: 0s;
+          transition-delay: var(--linespace-transition-delay);
         }
       }
 
       .menu {
-        display: flexbox;
         position: relative;
         height: 100%;
         left: 100%;
@@ -362,7 +362,6 @@ router.afterEach(() => {
 
             .sub-menu-toggle {
               cursor: pointer;
-              padding: auto;
               float: right;
               width: 15vw;
               margin-right: 1em;

--- a/src/layouts/NavMobile.vue
+++ b/src/layouts/NavMobile.vue
@@ -13,10 +13,11 @@ const state = stateStore();
 const items = content.items;
 
 function toggleNavLevel() {
-  if (state.state.navLevel) {
+  if (state.state.navLevel >= 1) {
+    state.state.lastNavLevel = state.state.navLevel;
     state.state.navLevel = 0;
   } else {
-    state.state.navLevel = 1;
+    state.state.navLevel = state.state.lastNavLevel;
   }
 }
 
@@ -35,7 +36,7 @@ function setCurrentLevel(level: 0 | 1 | 2 | 3, name?: string) {
   if (level < 2) {
     currentLevel2.value = '';
   }
-  state.state.navLevel = level;
+  state.state.navLevel = state.state.lastNavLevel = level;
 }
 
 const router = useRouter();

--- a/src/layouts/NavMobile.vue
+++ b/src/layouts/NavMobile.vue
@@ -184,7 +184,6 @@ router.afterEach(() => {
   --transition-time: 0.2s;
   --linespace: 3vw;
   --shadowspace: 6vw;
-  --linespace-transition-delay: calc(var(--transition-time) * 0.5);
 
   a {
     cursor: pointer;
@@ -304,14 +303,14 @@ router.afterEach(() => {
       height: 100%;
       width: 100vw - var(--shadowspace); // 100%
       transition: var(--transition-time) ease-in-out;
-      transition-delay: var(--linespace-transition-delay);
+      transition-delay: var(--transition-time);
 
       &.blue {
         background-color: var(--indi-blue-1);
 
         &.visible {
           left: (var(--shadowspace));
-          transition-delay: var(--linespace-transition-delay);
+          transition-delay: 0s;
         }
       }
 
@@ -323,7 +322,7 @@ router.afterEach(() => {
 
         &.visible {
           left: 0;
-          transition-delay: var(--linespace-transition-delay);
+          transition-delay: 0s;
         }
       }
 
@@ -335,7 +334,7 @@ router.afterEach(() => {
 
         &.visible {
           left: 0;
-          transition-delay: var(--linespace-transition-delay);
+          transition-delay: 0s;
         }
       }
 

--- a/src/stores/state.ts
+++ b/src/stores/state.ts
@@ -11,6 +11,7 @@ export const stateStore = defineStore({
     },
     state: {
       navLevel: 0, // 0 is closed
+      lastNavLevel: 1,
     },
   }),
   actions: {


### PR DESCRIPTION
Zoals in de beschrijving van issue #40 staat, zijn de lijnen van het mobile navmenu wat uitgedund naar de helft van hun oorspronkelijke breedte.
Daarnaast is de transition delay ook verminderd tot de helft van de oorspronkelijke waarde, waardoor deze er nog wel is, maar niet meer telkens het hele scherm vult. De  animatie voelt/verloopt nu ook iets sneller.

closes #40 

![navmenu1](https://github.com/svIndicium/site/assets/25852341/d8ea1c8f-cc72-4b16-9fd2-72f51a45555f)

