### PR TITLE
Tekst voor lege kalender

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -112,10 +112,10 @@ function extractHourAndMinutes(timeString: string) {
 <template>
   <h2 class="title">Agenda</h2>
   <div class="events-container">
-    <p v-if="!visibleEvents.length">
-      Binnenkort zijn er nog geen activiteiten.
-      Voeg de kalender toe aan je agenda om up-to-date te blijven!
-    </p>
+    <article v-if="!visibleEvents.length">
+      <p>Voorlopig zijn er geen activiteiten.</p>
+      <p>Voeg de kalender toe aan je agenda om up-to-date te blijven!</p>
+    </article>
     <div class="event" v-for="event in visibleEvents" :key="event.id">
       <div class="date">
         <span class="day">{{ event.start.toLocaleDateString('nl', { day: 'numeric' }) }}</span>

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -112,6 +112,10 @@ function extractHourAndMinutes(timeString: string) {
 <template>
   <h2 class="title">Agenda</h2>
   <div class="events-container">
+    <p v-if="!visibleEvents.length">
+      Binnenkort zijn er nog geen activiteiten.
+      Voeg de kalender toe aan je agenda om up-to-date te blijven!
+    </p>
     <div class="event" v-for="event in visibleEvents" :key="event.id">
       <div class="date">
         <span class="day">{{ event.start.toLocaleDateString('nl', { day: 'numeric' }) }}</span>


### PR DESCRIPTION
Per ongeluk aanvankelijk gepusht naar main en kan het niet ongedaan maken, dus dit is puur een formaliteitje.

Anyway, zie hier:

![image](https://github.com/svIndicium/site/assets/25852341/f532bca9-11fb-4edf-909f-e6849a10779b)

closes #16 