### PR TITLE
40b Mobile nav menu naar level 1 na navigeren.

### DIFF
--- a/src/layouts/NavMobile.vue
+++ b/src/layouts/NavMobile.vue
@@ -13,11 +13,11 @@ const state = stateStore();
 const items = content.items;
 
 function toggleNavLevel() {
-  if (state.state.navLevel >= 1) {
-    state.state.lastNavLevel = state.state.navLevel;
+  if (state.state.navLevel) {
     state.state.navLevel = 0;
   } else {
-    state.state.navLevel = state.state.lastNavLevel;
+    state.state.navLevel = 1;
+    setCurrentLevel(1);
   }
 }
 
@@ -36,7 +36,7 @@ function setCurrentLevel(level: 0 | 1 | 2 | 3, name?: string) {
   if (level < 2) {
     currentLevel2.value = '';
   }
-  state.state.navLevel = state.state.lastNavLevel = level;
+  state.state.navLevel = level;
 }
 
 const router = useRouter();

--- a/src/stores/state.ts
+++ b/src/stores/state.ts
@@ -10,8 +10,7 @@ export const stateStore = defineStore({
       theme: 'auto',
     },
     state: {
-      navLevel: 0, // 0 is closed
-      lastNavLevel: 1,
+      navLevel: 0,  // 0 is closed
     },
   }),
   actions: {


### PR DESCRIPTION
Mobile nav gaat nu zoals gevraagd altijd terug naar level 1 na het navigeren.

fix #40  