### PR TITLE
95 iOS Aanmeldformulier checkboxes

### DIFF
--- a/src/components/ConscriboForm.vue
+++ b/src/components/ConscriboForm.vue
@@ -43,8 +43,8 @@ fetchConscriboFormAndInjectFix(conscriboFormUrl);
     td {
       // Make checkboxes bigger and color them
       input[type='checkbox'] {
-        transform: scale(2); // Scale up the checkbox
-        margin: 20px 10px;
+        width: 1.5em;
+        height: 1.5em;
         accent-color: #a3cf9b;
       }
 
@@ -109,25 +109,24 @@ fetchConscriboFormAndInjectFix(conscriboFormUrl);
         .accountTable:first-of-type td {
           text-align: center;
           padding: 0;
+        }
 
-          input {
-            margin-left: 0;
-          }
+        .inputDivWithLabel {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
         }
 
         input {
           width: 90% !important;
-          margin-left: 5%;
         }
 
         input[type='checkbox'] {
-          margin: 20px 0;
-          margin-left: 5%;
+          margin: 1em 0;
         }
 
         select {
           width: 90% !important;
-          margin-left: 5%;
           text-align: center;
         }
 

--- a/src/components/ConscriboForm.vue
+++ b/src/components/ConscriboForm.vue
@@ -74,9 +74,12 @@ fetchConscriboFormAndInjectFix(conscriboFormUrl);
           .inputDivWithLabel {
             display: flex;
             flex-direction: row;
-            align-items: right;
             order: 2;
-            margin-left: 10px;
+            margin: 0 8px;
+
+            input[type='checkbox'] {
+              transform: translateY(25%);
+            }
 
             // error label handling desktop
             position: relative;

--- a/src/views/LidWorden.vue
+++ b/src/views/LidWorden.vue
@@ -108,7 +108,7 @@ setInterval(() => {
     <ConscriboForm />
     <p>
       Gaat er iets niet helemaal goed? Geen zorgen,
-      <a href="https://leden.conscribo.nl/svIndicium/aanmeldenlidmaatschap_v2" target="_blank"
+      <a href="https://leden.conscribo.nl/svIndicium/aanmeldenlidmaatschap" target="_blank"
         >open het formulier in een nieuw tabblad</a
       >
       en probeer het nog een keer. 🙂


### PR DESCRIPTION
Checkboxes werken weer op iOS/webkit. Heb de CSS best wel aangepast, dus ook de overige velden worden nu gecentreerd met flex, ipv gaar getover met margins e.d.  De checkboxes zijn niet gecentreerd op iOS, maar dat is een andere issue. Op desktop en android is het wel gewoon gecentered.

closes #95 